### PR TITLE
28 add crash detection logic

### DIFF
--- a/components/app-crash-detector/CMakeLists.txt
+++ b/components/app-crash-detector/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "crash_detector.c"
     INCLUDE_DIRS "."
-    REQUIRES driver freertos acc-LIS2DH12TR
+    REQUIRES driver freertos acc-LIS2DH12TR io-expander-pcf8574
 )

--- a/components/app-crash-detector/crash_detector.c
+++ b/components/app-crash-detector/crash_detector.c
@@ -8,55 +8,39 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/timers.h"
-#include "driver/uart.h"
 #include <string.h>
 #include <time.h>
 #include <math.h>
+#include "pcf8574.h"
 
 #define TAG "CRASH_DETECTOR"
 
-// UART configuration for sending notifications to ESP32-CAM
-#define UART_NUM       UART_NUM_1
-#define UART_TX_PIN    1 // TXD0 pin (GPIO1)
-#define UART_RX_PIN    3 // RXD0 pin (GPIO3)
-#define UART_BAUD_RATE 115200
-
 // Sampling interval (ms)
-#define SAMPLE_INTERVAL_MS 50 // 50Hz sampling rate for fast detection
+#define SAMPLE_INTERVAL_MS 50
 
-// Configuration and state variables
+// PCF8574 I/O expander pin used for crash detection signal
+extern i2c_dev_t expander;            // Declared in app_main
+static uint8_t expander_state = 0xFF; // Default all HIGH (idle)
+#define CRASH_DET_PIN 0               // P0 on PCF8574
+
+// Config and state
 static float crash_threshold                        = CRASH_ACCEL_THRESHOLD;
 static bool crash_detected                          = false;
 static crash_event_t last_crash_event               = { 0 };
 static TimerHandle_t reset_timer                    = NULL;
 static void (*crash_callback)(crash_event_t *event) = NULL;
 
-// Mock timestamp counter (instead of SNTP)
-static time_t mock_timestamp = 1712342400; // April 5, 2024 12:00:00 UTC
+// Mock time for demo
+static time_t mock_timestamp = 1712342400;
 
-/**
- * @brief Generate a mock timestamp
- * 
- * @return time_t Current mock time
- */
 static time_t get_mock_time(void) {
-    // Increment mock time by sampling interval
     mock_timestamp += (SAMPLE_INTERVAL_MS / 1000);
     return mock_timestamp;
 }
 
-/**
- * @brief Format timestamp to human-readable string with underscores instead of colons
- * 
- * @param ts Unix timestamp
- * @param buf Output buffer
- * @param size Buffer size
- */
 static void format_timestamp(time_t ts, char *buf, size_t size) {
     struct tm timeinfo;
     localtime_r(&ts, &timeinfo);
-
-    // Format: YYYY-MM-DD HH_MM_SS (using underscores instead of colons)
     snprintf(buf,
             size,
             "%04d-%02d-%02d %02d_%02d_%02d",
@@ -68,21 +52,22 @@ static void format_timestamp(time_t ts, char *buf, size_t size) {
             timeinfo.tm_sec);
 }
 
+// === NEW: PCF8574 GPIO helper ===
+static void pcf8574_set_pin(uint8_t pin, bool high) {
+    if(high)
+        expander_state |= (1 << pin); // release line (idle)
+    else
+        expander_state &= ~(1 << pin); // pull low (signal)
+
+    pcf8574_port_write(&expander, expander_state);
+}
+
 /**
- * @brief Send crash notification via UART
- *
- * @param event Crash event data
+ * @brief Send crash notification (via I/O expander pin)
  */
 static void send_crash_notification(crash_event_t *event) {
-    char notification[64];
-
-    // Send only the timestamp to UART for simpler parsing
-    snprintf(notification, sizeof(notification), "%s\n", event->timestamp_str);
-
-    uart_write_bytes(UART_NUM, notification, strlen(notification));
-
-    // Keep the full log message for console debugging
-    ESP_LOGI(TAG, "CRASH DETECTED! Force: %.2fg, Time: %s", event->impact_force, event->timestamp_str);
+    pcf8574_set_pin(CRASH_DET_PIN, false); // Pull LOW to signal
+    ESP_LOGW(TAG, "Crash signal sent via PCF8574 P%d (LOW)", CRASH_DET_PIN);
 }
 
 /**
@@ -90,78 +75,38 @@ static void send_crash_notification(crash_event_t *event) {
  */
 static void reset_timer_callback(TimerHandle_t xTimer) {
     crash_detected = false;
-    ESP_LOGI(TAG, "Crash state auto-reset after timeout");
+    pcf8574_set_pin(CRASH_DET_PIN, true); // Release pin (HIGH)
+    ESP_LOGW(TAG, "Crash reset: pin released (HIGH)");
 }
 
 esp_err_t crash_detector_init(void) {
-    // Configure UART for notification
-    uart_config_t uart_config = {
-        .baud_rate           = UART_BAUD_RATE,
-        .data_bits           = UART_DATA_8_BITS,
-        .parity              = UART_PARITY_DISABLE,
-        .stop_bits           = UART_STOP_BITS_1,
-        .flow_ctrl           = UART_HW_FLOWCTRL_DISABLE,
-        .rx_flow_ctrl_thresh = 0,
-        .source_clk          = UART_SCLK_DEFAULT,
-    };
+    // Reset state
+    crash_detected = false;
+    pcf8574_set_pin(CRASH_DET_PIN, true); // Idle state: HIGH
 
-    // Install UART driver
-    ESP_LOGI(TAG, "Initializing UART for crash notifications");
-    esp_err_t ret = uart_driver_install(UART_NUM, 256, 0, 0, NULL, 0);
-    if(ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to install UART driver: %s", esp_err_to_name(ret));
-        return ret;
-    }
+    reset_timer = xTimerCreate("crash_reset_timer", pdMS_TO_TICKS(CRASH_RESET_TIMEOUT_MS), pdFALSE, 0, reset_timer_callback);
 
-    ret = uart_param_config(UART_NUM, &uart_config);
-    if(ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to configure UART parameters: %s", esp_err_to_name(ret));
-        return ret;
-    }
-
-    ret = uart_set_pin(UART_NUM, UART_TX_PIN, UART_RX_PIN, -1, -1);
-    if(ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to set UART pins: %s", esp_err_to_name(ret));
-        return ret;
-    }
-
-    // Create auto-reset timer
-    reset_timer = xTimerCreate("crash_reset_timer",
-            pdMS_TO_TICKS(CRASH_RESET_TIMEOUT_MS),
-            pdFALSE, // One-shot timer
-            0,
-            reset_timer_callback);
-
-    if(reset_timer == NULL) {
+    if(!reset_timer) {
         ESP_LOGE(TAG, "Failed to create crash reset timer");
         return ESP_FAIL;
     }
 
-    ESP_LOGI(TAG, "Crash detector initialized with threshold: %.2fg", crash_threshold);
+    ESP_LOGE(TAG, "Crash detector initialized with threshold: %.2fg", crash_threshold);
     return ESP_OK;
 }
 
 void crash_detector_task(void *pvParameters) {
-    // Ensure LIS2DH12TR accelerometer is initialized
-    // Note: We assume the accelerometer is already initialized by the
-    // speed estimator component, so we don't initialize it again here
-
     LIS2DH12TR_accelerations acc = { 0 };
     float impact_magnitude;
 
-    ESP_LOGI(TAG, "Crash detector task started");
+    ESP_LOGE(TAG, "Crash detector task started");
 
     while(1) {
         if(LIS2DH12TR_read_acc(&acc) == LIS2DH12TR_READING_OK) {
-            // Calculate total impact force (vector magnitude of acceleration)
-            impact_magnitude = sqrtf(acc.x_acc * acc.x_acc + acc.y_acc * acc.y_acc + acc.z_acc * acc.z_acc);
-
-            // Check for crash (subtract 1g for earth's gravity)
+            impact_magnitude         = sqrtf(acc.x_acc * acc.x_acc + acc.y_acc * acc.y_acc + acc.z_acc * acc.z_acc);
             float adjusted_magnitude = impact_magnitude > 1.0f ? impact_magnitude - 1.0f : 0.0f;
 
-            // Crash detection logic
             if(adjusted_magnitude > crash_threshold && !crash_detected) {
-                // Create crash event
                 crash_detected                = true;
                 last_crash_event.impact_force = adjusted_magnitude;
                 last_crash_event.timestamp    = get_mock_time();
@@ -169,21 +114,15 @@ void crash_detector_task(void *pvParameters) {
                         last_crash_event.timestamp_str,
                         sizeof(last_crash_event.timestamp_str));
 
-                // Send notification
                 send_crash_notification(&last_crash_event);
 
-                // Notify callback if registered
-                if(crash_callback != NULL) {
+                if(crash_callback)
                     crash_callback(&last_crash_event);
-                }
-
-                // Start auto-reset timer
                 xTimerStart(reset_timer, 0);
 
-                ESP_LOGI(TAG, "Crash detected! Force: %.2fg", adjusted_magnitude);
+                ESP_LOGE(TAG, "Crash detected! Force: %.2fg", adjusted_magnitude);
             }
 
-            // Optional: Log high impacts even if not a crash
             if(adjusted_magnitude > crash_threshold / 2) {
                 ESP_LOGD(TAG, "High impact detected: %.2fg", adjusted_magnitude);
             }
@@ -198,23 +137,22 @@ bool crash_detector_is_crashed(void) {
 }
 
 bool crash_detector_get_last_event(crash_event_t *event) {
-    if(!crash_detected || event == NULL) {
+    if(!crash_detected || !event)
         return false;
-    }
-
     memcpy(event, &last_crash_event, sizeof(crash_event_t));
     return true;
 }
 
 void crash_detector_reset(void) {
     crash_detected = false;
-    ESP_LOGI(TAG, "Crash state manually reset");
+    pcf8574_set_pin(CRASH_DET_PIN, true); // release
+    ESP_LOGE(TAG, "Crash state manually reset");
 }
 
 void crash_detector_set_threshold(float threshold) {
     if(threshold > 0) {
         crash_threshold = threshold;
-        ESP_LOGI(TAG, "Crash threshold updated to %.2fg", threshold);
+        ESP_LOGE(TAG, "Crash threshold updated to %.2fg", threshold);
     }
 }
 

--- a/components/app-crash-detector/crash_detector.h
+++ b/components/app-crash-detector/crash_detector.h
@@ -10,7 +10,7 @@
 #include <time.h>
 
 /** @brief Impact threshold in g-forces */
-#define CRASH_ACCEL_THRESHOLD  4.0f // Default: 4g force
+#define CRASH_ACCEL_THRESHOLD  0.2f // Default: 4g force
 #define CRASH_RESET_TIMEOUT_MS 5000 // Auto reset crash state after 5 seconds
 
 /**

--- a/components/app-door-detector/CMakeLists.txt
+++ b/components/app-door-detector/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "door_detector.c"
     INCLUDE_DIRS "."
-    REQUIRES driver freertos infrared-tcrt5000
+    REQUIRES driver freertos infrared-tcrt5000 io-expander-pcf8574
 )

--- a/components/app-door-detector/door_detector.c
+++ b/components/app-door-detector/door_detector.c
@@ -10,6 +10,8 @@
 #include "freertos/event_groups.h"
 #include "freertos/queue.h"
 #include "driver/gpio.h"
+#include "pcf8574.h"
+
 
 #define TAG "DOOR_DETECTOR"
 
@@ -17,14 +19,22 @@
 #define DOOR_OPEN_BIT   BIT0
 #define DOOR_CLOSED_BIT BIT1
 
-#define TCRT5000_DIGITAL_PIN GPIO_NUM_14 // LED_B 13
+#define TCRT5000_DIGITAL_PIN 1 // LPCF8574 P1 for emitter power
 
 // Queue size for events
 #define DOOR_EVENT_QUEUE_SIZE 10
 
 // Sensor configuration
 static tcrt5000_handle_t sensor;
-static const tcrt5000_config_t config = { .use_digital = true, .digital_pin = TCRT5000_DIGITAL_PIN, .invert_output = true };
+static const tcrt5000_config_t config = {
+    .use_digital   = true,
+    .digital_pin   = 1,    // P1 on PCF8574 (bit index)
+    .use_expander  = true, // tell driver to read from expander
+    .invert_output = true  // true = LOW means detected
+};
+
+extern i2c_dev_t expander;
+extern uint8_t expander_state;
 
 // Internal state
 static EventGroupHandle_t door_event_group       = NULL;

--- a/components/i2cdev/.eil.yml
+++ b/components/i2cdev/.eil.yml
@@ -1,0 +1,29 @@
+---
+name: i2cdev
+description: ESP-IDF I2C master thread-safe utilities
+version: 1.5.0
+groups:
+  - common
+code_owners:
+  - UncleRus
+depends:
+  - driver
+  - freertos
+  - esp_idf_lib_helpers
+thread_safe: yes
+targets:
+  - esp32
+  - esp8266
+  - esp32s2
+  - esp32c3
+  - esp32s3
+  - esp32c2
+  - esp32c6
+  - esp32h2
+  - esp32p4
+  - esp32c5
+  - esp32c61
+license: MIT
+copyrights:
+  - name: UncleRus
+    year: 2018

--- a/components/i2cdev/CMakeLists.txt
+++ b/components/i2cdev/CMakeLists.txt
@@ -1,0 +1,11 @@
+if(${IDF_TARGET} STREQUAL esp8266)
+    set(req esp8266 freertos esp_idf_lib_helpers)
+else()
+    set(req driver freertos esp_idf_lib_helpers)
+endif()
+
+idf_component_register(
+    SRCS i2cdev.c
+    INCLUDE_DIRS .
+    REQUIRES ${req}
+)

--- a/components/i2cdev/Kconfig
+++ b/components/i2cdev/Kconfig
@@ -1,0 +1,17 @@
+menu "I2C"
+
+config I2CDEV_TIMEOUT
+    int "I2C transaction timeout, milliseconds"
+    default 1000
+    range 10 5000
+    
+config I2CDEV_NOLOCK
+	bool "Disable the use of mutexes"
+	default n
+	help
+		Attention! After enabling this option, all I2C device
+		drivers will become non-thread safe. 
+		Use this option if you need to access your I2C devices
+		from interrupt handlers. 
+    
+endmenu

--- a/components/i2cdev/LICENSE
+++ b/components/i2cdev/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Ruslan V. Uss (https://github.com/UncleRus)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/i2cdev/component.mk
+++ b/components/i2cdev/component.mk
@@ -1,0 +1,7 @@
+COMPONENT_ADD_INCLUDEDIRS = .
+
+ifdef CONFIG_IDF_TARGET_ESP8266
+COMPONENT_DEPENDS = esp8266 freertos esp_idf_lib_helpers
+else
+COMPONENT_DEPENDS = driver freertos esp_idf_lib_helpers
+endif

--- a/components/i2cdev/i2cdev.c
+++ b/components/i2cdev/i2cdev.c
@@ -1,0 +1,324 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file i2cdev.c
+ *
+ * ESP-IDF I2C master thread-safe functions for communication with I2C slave
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * MIT Licensed as described in the file LICENSE
+ */
+#include <string.h>
+#include <inttypes.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <esp_log.h>
+#include "i2cdev.h"
+
+static const char *TAG = "i2cdev";
+
+typedef struct {
+    SemaphoreHandle_t lock;
+    i2c_config_t config;
+    bool installed;
+} i2c_port_state_t;
+
+static i2c_port_state_t states[I2C_NUM_MAX];
+
+#if CONFIG_I2CDEV_NOLOCK
+#define SEMAPHORE_TAKE(port)
+#else
+#define SEMAPHORE_TAKE(port)                                                           \
+    do {                                                                               \
+        if(!xSemaphoreTake(states[port].lock, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT))) { \
+            ESP_LOGE(TAG, "Could not take port mutex %d", port);                       \
+            return ESP_ERR_TIMEOUT;                                                    \
+        }                                                                              \
+    } while(0)
+#endif
+
+#if CONFIG_I2CDEV_NOLOCK
+#define SEMAPHORE_GIVE(port)
+#else
+#define SEMAPHORE_GIVE(port)                                     \
+    do {                                                         \
+        if(!xSemaphoreGive(states[port].lock)) {                 \
+            ESP_LOGE(TAG, "Could not give port mutex %d", port); \
+            return ESP_FAIL;                                     \
+        }                                                        \
+    } while(0)
+#endif
+
+esp_err_t i2cdev_init() {
+    memset(states, 0, sizeof(states));
+
+#if !CONFIG_I2CDEV_NOLOCK
+    for(int i = 0; i < I2C_NUM_MAX; i++) {
+        states[i].lock = xSemaphoreCreateMutex();
+        if(!states[i].lock) {
+            ESP_LOGE(TAG, "Could not create port mutex %d", i);
+            return ESP_FAIL;
+        }
+    }
+#endif
+
+    return ESP_OK;
+}
+
+esp_err_t i2cdev_done() {
+    for(int i = 0; i < I2C_NUM_MAX; i++) {
+        if(!states[i].lock)
+            continue;
+
+        if(states[i].installed) {
+            SEMAPHORE_TAKE(i);
+            i2c_driver_delete(i);
+            states[i].installed = false;
+            SEMAPHORE_GIVE(i);
+        }
+#if !CONFIG_I2CDEV_NOLOCK
+        vSemaphoreDelete(states[i].lock);
+#endif
+        states[i].lock = NULL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_create_mutex(i2c_dev_t *dev) {
+#if !CONFIG_I2CDEV_NOLOCK
+    if(!dev)
+        return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] creating mutex", dev->addr, dev->port);
+
+    dev->mutex = xSemaphoreCreateMutex();
+    if(!dev->mutex) {
+        ESP_LOGE(TAG, "[0x%02x at %d] Could not create device mutex", dev->addr, dev->port);
+        return ESP_FAIL;
+    }
+#endif
+
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_delete_mutex(i2c_dev_t *dev) {
+#if !CONFIG_I2CDEV_NOLOCK
+    if(!dev)
+        return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] deleting mutex", dev->addr, dev->port);
+
+    vSemaphoreDelete(dev->mutex);
+#endif
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_take_mutex(i2c_dev_t *dev) {
+#if !CONFIG_I2CDEV_NOLOCK
+    if(!dev)
+        return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] taking mutex", dev->addr, dev->port);
+
+    if(!xSemaphoreTake(dev->mutex, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT))) {
+        ESP_LOGE(TAG, "[0x%02x at %d] Could not take device mutex", dev->addr, dev->port);
+        return ESP_ERR_TIMEOUT;
+    }
+#endif
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_give_mutex(i2c_dev_t *dev) {
+#if !CONFIG_I2CDEV_NOLOCK
+    if(!dev)
+        return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] giving mutex", dev->addr, dev->port);
+
+    if(!xSemaphoreGive(dev->mutex)) {
+        ESP_LOGE(TAG, "[0x%02x at %d] Could not give device mutex", dev->addr, dev->port);
+        return ESP_FAIL;
+    }
+#endif
+    return ESP_OK;
+}
+
+inline static bool cfg_equal(const i2c_config_t *a, const i2c_config_t *b) {
+    return a->scl_io_num == b->scl_io_num && a->sda_io_num == b->sda_io_num
+#if HELPER_TARGET_IS_ESP32
+           && a->master.clk_speed == b->master.clk_speed
+#elif HELPER_TARGET_IS_ESP8266
+           && ((a->clk_stretch_tick && a->clk_stretch_tick == b->clk_stretch_tick)
+                   || (!a->clk_stretch_tick && b->clk_stretch_tick == I2CDEV_MAX_STRETCH_TIME)) // see line 232
+#endif
+           && a->scl_pullup_en == b->scl_pullup_en && a->sda_pullup_en == b->sda_pullup_en;
+}
+
+static esp_err_t i2c_setup_port(const i2c_dev_t *dev) {
+    if(dev->port >= I2C_NUM_MAX)
+        return ESP_ERR_INVALID_ARG;
+
+    esp_err_t res;
+    if(!cfg_equal(&dev->cfg, &states[dev->port].config) || !states[dev->port].installed) {
+        ESP_LOGD(TAG, "Reconfiguring I2C driver on port %d", dev->port);
+        i2c_config_t temp;
+        memcpy(&temp, &dev->cfg, sizeof(i2c_config_t));
+        temp.mode = I2C_MODE_MASTER;
+
+        // Driver reinstallation
+        if(states[dev->port].installed) {
+            i2c_driver_delete(dev->port);
+            states[dev->port].installed = false;
+        }
+#if HELPER_TARGET_IS_ESP32
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+        // See https://github.com/espressif/esp-idf/issues/10163
+        if((res = i2c_driver_install(dev->port, temp.mode, 0, 0, 0)) != ESP_OK)
+            return res;
+        if((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
+            return res;
+#else
+        if((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
+            return res;
+            // if ((res = i2c_driver_install(dev->port, temp.mode, 0, 0, 0)) != ESP_OK)
+            //     return res;
+#endif
+#endif
+#if HELPER_TARGET_IS_ESP8266
+        // Clock Stretch time, depending on CPU frequency
+        temp.clk_stretch_tick = dev->timeout_ticks ? dev->timeout_ticks : I2CDEV_MAX_STRETCH_TIME;
+        if((res = i2c_driver_install(dev->port, temp.mode)) != ESP_OK)
+            return res;
+        if((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
+            return res;
+#endif
+        states[dev->port].installed = true;
+
+        memcpy(&states[dev->port].config, &temp, sizeof(i2c_config_t));
+        ESP_LOGD(TAG, "I2C driver successfully reconfigured on port %d", dev->port);
+    }
+#if HELPER_TARGET_IS_ESP32
+    int t;
+    if((res = i2c_get_timeout(dev->port, &t)) != ESP_OK)
+        return res;
+    // Timeout cannot be 0
+    uint32_t ticks = dev->timeout_ticks ? dev->timeout_ticks : I2CDEV_MAX_STRETCH_TIME;
+    if((ticks != t) && (res = i2c_set_timeout(dev->port, ticks)) != ESP_OK)
+        return res;
+    ESP_LOGD(TAG,
+            "Timeout: ticks = %" PRIu32 " (%" PRIu32 " usec) on port %d",
+            dev->timeout_ticks,
+            dev->timeout_ticks / 80,
+            dev->port);
+#endif
+
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_probe(const i2c_dev_t *dev, i2c_dev_type_t operation_type) {
+    if(!dev)
+        return ESP_ERR_INVALID_ARG;
+
+    SEMAPHORE_TAKE(dev->port);
+
+    esp_err_t res = i2c_setup_port(dev);
+    if(res == ESP_OK) {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, dev->addr << 1 | (operation_type == I2C_DEV_READ ? 1 : 0), true);
+        i2c_master_stop(cmd);
+
+        res = i2c_master_cmd_begin(dev->port, cmd, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT));
+
+        i2c_cmd_link_delete(cmd);
+    }
+
+    SEMAPHORE_GIVE(dev->port);
+
+    return res;
+}
+
+esp_err_t i2c_dev_read(const i2c_dev_t *dev, const void *out_data, size_t out_size, void *in_data, size_t in_size) {
+    if(!dev || !in_data || !in_size)
+        return ESP_ERR_INVALID_ARG;
+
+    SEMAPHORE_TAKE(dev->port);
+
+    esp_err_t res = i2c_setup_port(dev);
+    if(res == ESP_OK) {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        if(out_data && out_size) {
+            i2c_master_start(cmd);
+            i2c_master_write_byte(cmd, dev->addr << 1, true);
+            i2c_master_write(cmd, (void *) out_data, out_size, true);
+        }
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (dev->addr << 1) | 1, true);
+        i2c_master_read(cmd, in_data, in_size, I2C_MASTER_LAST_NACK);
+        i2c_master_stop(cmd);
+
+        res = i2c_master_cmd_begin(dev->port, cmd, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT));
+        if(res != ESP_OK)
+            ESP_LOGE(TAG, "Could not read from device [0x%02x at %d]: %d (%s)", dev->addr, dev->port, res, esp_err_to_name(res));
+
+        i2c_cmd_link_delete(cmd);
+    }
+
+    SEMAPHORE_GIVE(dev->port);
+    return res;
+}
+
+esp_err_t i2c_dev_write(const i2c_dev_t *dev, const void *out_reg, size_t out_reg_size, const void *out_data, size_t out_size) {
+    if(!dev || !out_data || !out_size)
+        return ESP_ERR_INVALID_ARG;
+
+    SEMAPHORE_TAKE(dev->port);
+
+    esp_err_t res = i2c_setup_port(dev);
+    if(res == ESP_OK) {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, dev->addr << 1, true);
+        if(out_reg && out_reg_size)
+            i2c_master_write(cmd, (void *) out_reg, out_reg_size, true);
+        i2c_master_write(cmd, (void *) out_data, out_size, true);
+        i2c_master_stop(cmd);
+        res = i2c_master_cmd_begin(dev->port, cmd, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT));
+        if(res != ESP_OK)
+            ESP_LOGE(TAG, "Could not write to device [0x%02x at %d]: %d (%s)", dev->addr, dev->port, res, esp_err_to_name(res));
+        i2c_cmd_link_delete(cmd);
+    }
+
+    SEMAPHORE_GIVE(dev->port);
+    return res;
+}
+
+esp_err_t i2c_dev_read_reg(const i2c_dev_t *dev, uint8_t reg, void *in_data, size_t in_size) {
+    return i2c_dev_read(dev, &reg, 1, in_data, in_size);
+}
+
+esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg, const void *out_data, size_t out_size) {
+    return i2c_dev_write(dev, &reg, 1, out_data, out_size);
+}

--- a/components/i2cdev/i2cdev.h
+++ b/components/i2cdev/i2cdev.h
@@ -1,0 +1,252 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file i2cdev.h
+ * @defgroup i2cdev i2cdev
+ * @{
+ *
+ * ESP-IDF I2C master thread-safe functions for communication with I2C slave
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * MIT Licensed as described in the file LICENSE
+ */
+#ifndef __I2CDEV_H__
+#define __I2CDEV_H__
+
+#include <driver/i2c.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <esp_err.h>
+#include <esp_idf_lib_helpers.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HELPER_TARGET_IS_ESP8266
+
+#define I2CDEV_MAX_STRETCH_TIME 0xffffffff
+
+#else
+
+#include <soc/i2c_reg.h>
+#if defined(I2C_TIME_OUT_VALUE_V)
+#define I2CDEV_MAX_STRETCH_TIME I2C_TIME_OUT_VALUE_V
+#elif defined(I2C_TIME_OUT_REG_V)
+#define I2CDEV_MAX_STRETCH_TIME I2C_TIME_OUT_REG_V
+#else
+#define I2CDEV_MAX_STRETCH_TIME 0x00ffffff
+#endif
+
+#endif /* HELPER_TARGET_IS_ESP8266 */
+
+/**
+ * I2C device descriptor
+ */
+typedef struct {
+    i2c_port_t port;         //!< I2C port number
+    i2c_config_t cfg;        //!< I2C driver configuration
+    uint8_t addr;            //!< Unshifted address
+    SemaphoreHandle_t mutex; //!< Device mutex
+    uint32_t timeout_ticks;  /*!< HW I2C bus timeout (stretch time), in ticks. 80MHz APB clock
+                                  ticks for ESP-IDF, CPU ticks for ESP8266.
+                                  When this value is 0, I2CDEV_MAX_STRETCH_TIME will be used */
+} i2c_dev_t;
+
+/**
+ * I2C transaction type
+ */
+typedef enum {
+    I2C_DEV_WRITE = 0, /**< Write operation */
+    I2C_DEV_READ       /**< Read operation */
+} i2c_dev_type_t;
+
+/**
+ * @brief Init library
+ *
+ * The function must be called before any other
+ * functions of this library.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t i2cdev_init();
+
+/**
+ * @brief Finish work with library
+ *
+ * Uninstall i2c drivers.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t i2cdev_done();
+
+/**
+ * @brief Create mutex for device descriptor
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_create_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Delete mutex for device descriptor
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_delete_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Take device mutex
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_take_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Give device mutex
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_give_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Check the availability of the device
+ *
+ * Issue an operation of \p operation_type to the I2C device then stops.
+ *
+ * @param dev Device descriptor
+ * @param operation_type Operation type
+ * @return ESP_OK if device is available
+ */
+esp_err_t i2c_dev_probe(const i2c_dev_t *dev, i2c_dev_type_t operation_type);
+
+/**
+ * @brief Read from slave device
+ *
+ * Issue a send operation of \p out_data register address, followed by reading \p in_size bytes
+ * from slave into \p in_data .
+ * Function is thread-safe.
+ *
+ * @param dev Device descriptor
+ * @param out_data Pointer to data to send if non-null
+ * @param out_size Size of data to send
+ * @param[out] in_data Pointer to input data buffer
+ * @param in_size Number of byte to read
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_read(const i2c_dev_t *dev, const void *out_data, size_t out_size, void *in_data, size_t in_size);
+
+/**
+ * @brief Write to slave device
+ *
+ * Write \p out_size bytes from \p out_data to slave into \p out_reg register address.
+ * Function is thread-safe.
+ *
+ * @param dev Device descriptor
+ * @param out_reg Pointer to register address to send if non-null
+ * @param out_reg_size Size of register address
+ * @param out_data Pointer to data to send
+ * @param out_size Size of data to send
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_write(const i2c_dev_t *dev, const void *out_reg, size_t out_reg_size, const void *out_data, size_t out_size);
+
+/**
+ * @brief Read from register with an 8-bit address
+ *
+ * Shortcut to ::i2c_dev_read().
+ *
+ * @param dev Device descriptor
+ * @param reg Register address
+ * @param[out] in_data Pointer to input data buffer
+ * @param in_size Number of byte to read
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_read_reg(const i2c_dev_t *dev, uint8_t reg, void *in_data, size_t in_size);
+
+/**
+ * @brief Write to register with an 8-bit address
+ *
+ * Shortcut to ::i2c_dev_write().
+ *
+ * @param dev Device descriptor
+ * @param reg Register address
+ * @param out_data Pointer to data to send
+ * @param out_size Size of data to send
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg, const void *out_data, size_t out_size);
+
+#define I2C_DEV_TAKE_MUTEX(dev)                 \
+    do {                                        \
+        esp_err_t __ = i2c_dev_take_mutex(dev); \
+        if(__ != ESP_OK)                        \
+            return __;                          \
+    } while(0)
+
+#define I2C_DEV_GIVE_MUTEX(dev)                 \
+    do {                                        \
+        esp_err_t __ = i2c_dev_give_mutex(dev); \
+        if(__ != ESP_OK)                        \
+            return __;                          \
+    } while(0)
+
+#define I2C_DEV_CHECK(dev, X)        \
+    do {                             \
+        esp_err_t ___ = X;           \
+        if(___ != ESP_OK) {          \
+            I2C_DEV_GIVE_MUTEX(dev); \
+            return ___;              \
+        }                            \
+    } while(0)
+
+#define I2C_DEV_CHECK_LOGE(dev, X, msg, ...)   \
+    do {                                       \
+        esp_err_t ___ = X;                     \
+        if(___ != ESP_OK) {                    \
+            I2C_DEV_GIVE_MUTEX(dev);           \
+            ESP_LOGE(TAG, msg, ##__VA_ARGS__); \
+            return ___;                        \
+        }                                      \
+    } while(0)
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/
+
+#endif /* __I2CDEV_H__ */

--- a/components/infrared-tcrt5000/CMakeLists.txt
+++ b/components/infrared-tcrt5000/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "tcrt5000.c"
     INCLUDE_DIRS "."
-    REQUIRES driver esp_adc
+    REQUIRES driver esp_adc io-expander-pcf8574
 )

--- a/components/infrared-tcrt5000/tcrt5000.c
+++ b/components/infrared-tcrt5000/tcrt5000.c
@@ -1,11 +1,17 @@
 /**
  * @file tcrt5000.c
- * @brief Implementation of TCRT5000 IR reflective sensor driver
+ * @brief Implementation of TCRT5000 IR reflective sensor driver (ESP32 + optional PCF8574 I/O expander)
  */
+
 #include "tcrt5000.h"
 #include "esp_log.h"
+#include "pcf8574.h"
+#include <stdbool.h>
 
 static const char *TAG = "TCRT5000";
+
+extern i2c_dev_t expander;
+extern uint8_t expander_state; // shared state for expander
 
 esp_err_t tcrt5000_init(const tcrt5000_config_t *config, tcrt5000_handle_t *handle) {
     if(config == NULL || handle == NULL) {
@@ -15,7 +21,15 @@ esp_err_t tcrt5000_init(const tcrt5000_config_t *config, tcrt5000_handle_t *hand
     // Copy configuration
     handle->config = *config;
 
-    if(config->use_digital) {
+    if(config->use_expander) {
+        // Set expander pin high to enable input mode
+        expander_state |= (1 << config->digital_pin);
+        esp_err_t ret   = pcf8574_port_write(&expander, expander_state);
+        if(ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to set expander pin %d as input: %s", config->digital_pin, esp_err_to_name(ret));
+            return ret;
+        }
+    } else if(config->use_digital) {
         // Configure GPIO for digital input
         gpio_config_t io_conf = { .pin_bit_mask = (1ULL << config->digital_pin),
             .mode                               = GPIO_MODE_INPUT,
@@ -25,25 +39,22 @@ esp_err_t tcrt5000_init(const tcrt5000_config_t *config, tcrt5000_handle_t *hand
 
         esp_err_t ret = gpio_config(&io_conf);
         if(ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to configure GPIO: %d", ret);
+            ESP_LOGE(TAG, "Failed to configure GPIO: %s", esp_err_to_name(ret));
             return ret;
         }
     } else {
         // Configure ADC for analog input
         esp_err_t ret = adc1_config_width(ADC_WIDTH_BIT_12);
         if(ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to configure ADC width: %d", ret);
+            ESP_LOGE(TAG, "Failed to configure ADC width: %s", esp_err_to_name(ret));
             return ret;
         }
 
         ret = adc1_config_channel_atten(config->adc_channel, ADC_ATTEN_DB_11);
         if(ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to configure ADC attenuation: %d", ret);
+            ESP_LOGE(TAG, "Failed to configure ADC attenuation: %s", esp_err_to_name(ret));
             return ret;
         }
-
-        // Characterize ADC for more accurate readings
-        // esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12, 0, &handle->adc_chars);
     }
 
     ESP_LOGI(TAG, "TCRT5000 sensor initialized successfully");
@@ -55,10 +66,12 @@ esp_err_t tcrt5000_read_raw(tcrt5000_handle_t *handle, uint32_t *value) {
         return ESP_ERR_INVALID_ARG;
     }
 
-    if(handle->config.use_digital) {
-        // If using digital input, just return the digital level multiplied by 4095
-        // to convert to same range as analog reading
-        *value = gpio_get_level(handle->config.digital_pin) ? 4095 : 0;
+    if(handle->config.use_digital || handle->config.use_expander) {
+        // For digital, return 4095 if high, 0 if low
+        bool detected = false;
+        esp_err_t ret = tcrt5000_read_digital(handle, &detected);
+        *value        = detected ? 4095 : 0;
+        return ret;
     } else {
         // Read raw ADC value
         int adc_raw = adc1_get_raw(handle->config.adc_channel);
@@ -66,12 +79,9 @@ esp_err_t tcrt5000_read_raw(tcrt5000_handle_t *handle, uint32_t *value) {
             ESP_LOGE(TAG, "Failed to read ADC value");
             return ESP_FAIL;
         }
-
-        // Convert ADC value to voltage in mV
-        // *value = esp_adc_cal_raw_to_voltage(adc_raw, &handle->adc_chars);
+        *value = (uint32_t) adc_raw;
+        return ESP_OK;
     }
-
-    return ESP_OK;
 }
 
 esp_err_t tcrt5000_read_digital(tcrt5000_handle_t *handle, bool *detected) {
@@ -79,18 +89,25 @@ esp_err_t tcrt5000_read_digital(tcrt5000_handle_t *handle, bool *detected) {
         return ESP_ERR_INVALID_ARG;
     }
 
-    if(handle->config.use_digital) {
-        // Direct digital reading
+    if(handle->config.use_expander) {
+        uint8_t port_val = 0;
+        esp_err_t ret    = pcf8574_port_read(&expander, &port_val);
+        if(ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to read from expander: %s", esp_err_to_name(ret));
+            return ret;
+        }
+
+        bool level = port_val & (1 << handle->config.digital_pin);
+        *detected  = handle->config.invert_output ? !level : level;
+    } else if(handle->config.use_digital) {
         int level = gpio_get_level(handle->config.digital_pin);
         *detected = handle->config.invert_output ? !level : level;
     } else {
-        // Read raw ADC value and compare with threshold
         uint32_t value;
         esp_err_t ret = tcrt5000_read_raw(handle, &value);
         if(ret != ESP_OK) {
             return ret;
         }
-
         bool detection = (value > handle->config.threshold);
         *detected      = handle->config.invert_output ? !detection : detection;
     }

--- a/components/infrared-tcrt5000/tcrt5000.h
+++ b/components/infrared-tcrt5000/tcrt5000.h
@@ -21,6 +21,7 @@ typedef struct {
     adc1_channel_t adc_channel; /*!< ADC channel for analog input */
     uint16_t threshold;         /*!< Threshold value for analog to digital conversion */
     bool invert_output;         /*!< Invert the output (true: detected = 0, false: detected = 1) */
+    bool use_expander;
 } tcrt5000_config_t;
 
 /**

--- a/components/io-expander-pcf8574/CMakeLists.txt
+++ b/components/io-expander-pcf8574/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS pcf8574.c
+    INCLUDE_DIRS .
+    REQUIRES i2cdev log esp_idf_lib_helpers
+)

--- a/components/io-expander-pcf8574/pcf8574.c
+++ b/components/io-expander-pcf8574/pcf8574.c
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file pcf8574.c
+ *
+ * ESP-IDF driver for PCF8574 compatible remote 8-bit I/O expanders for I2C-bus
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * MIT Licensed as described in the file LICENSE
+ */
+
+#include <esp_err.h>
+#include <esp_idf_lib_helpers.h>
+#include "pcf8574.h"
+
+#define I2C_FREQ_HZ 100000
+
+#define CHECK(x)               \
+    do {                       \
+        esp_err_t __;          \
+        if((__ = x) != ESP_OK) \
+            return __;         \
+    } while(0)
+#define CHECK_ARG(VAL)                  \
+    do {                                \
+        if(!(VAL))                      \
+            return ESP_ERR_INVALID_ARG; \
+    } while(0)
+#define BV(x) (1 << (x))
+
+static esp_err_t read_port(i2c_dev_t *dev, uint8_t *val) {
+    CHECK_ARG(dev && val);
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read(dev, NULL, 0, val, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+static esp_err_t write_port(i2c_dev_t *dev, uint8_t val) {
+    CHECK_ARG(dev);
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_write(dev, NULL, 0, &val, 1));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+esp_err_t pcf8574_init_desc(i2c_dev_t *dev, uint8_t addr, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio) {
+    CHECK_ARG(dev);
+    CHECK_ARG(addr & 0x20);
+
+    dev->port           = port;
+    dev->addr           = addr;
+    dev->cfg.sda_io_num = sda_gpio;
+    dev->cfg.scl_io_num = scl_gpio;
+#if HELPER_TARGET_IS_ESP32
+    dev->cfg.master.clk_speed = I2C_FREQ_HZ;
+#endif
+
+    return i2c_dev_create_mutex(dev);
+}
+
+esp_err_t pcf8574_free_desc(i2c_dev_t *dev) {
+    CHECK_ARG(dev);
+
+    return i2c_dev_delete_mutex(dev);
+}
+
+esp_err_t pcf8574_port_read(i2c_dev_t *dev, uint8_t *val) {
+    return read_port(dev, val);
+}
+
+esp_err_t pcf8574_port_write(i2c_dev_t *dev, uint8_t val) {
+    return write_port(dev, val);
+}

--- a/components/io-expander-pcf8574/pcf8574.h
+++ b/components/io-expander-pcf8574/pcf8574.h
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file pcf8574.h
+ * @defgroup pcf8574 pcf8574
+ * @{
+ *
+ * ESP-IDF driver for PCF8574 compatible remote 8-bit I/O expanders for I2C-bus
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * MIT Licensed as described in the file LICENSE
+ */
+#ifndef __PCF8574_H__
+#define __PCF8574_H__
+
+#include <stddef.h>
+#include <i2cdev.h>
+#include <esp_err.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize device descriptor
+ *
+ * Default SCL frequency is 100kHz
+ *
+ * @param dev Pointer to I2C device descriptor
+ * @param port I2C port number
+ * @param addr I2C address (0b0100[A2][A1][A0] for PCF8574, 0b0111[A2][A1][A0] for PCF8574A)
+ * @param sda_gpio SDA GPIO
+ * @param scl_gpio SCL GPIO
+ * @return `ESP_OK` on success
+ */
+esp_err_t pcf8574_init_desc(i2c_dev_t *dev, uint8_t addr, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio);
+
+/**
+ * @brief Free device descriptor
+ *
+ * @param dev Pointer to I2C device descriptor
+ * @return `ESP_OK` on success
+ */
+esp_err_t pcf8574_free_desc(i2c_dev_t *dev);
+
+/**
+ * @brief Read GPIO port value
+ *
+ * @param dev Pointer to I2C device descriptor
+ * @param val 8-bit GPIO port value
+ * @return `ESP_OK` on success
+ */
+esp_err_t pcf8574_port_read(i2c_dev_t *dev, uint8_t *val);
+
+/**
+ * @brief Write value to GPIO port
+ *
+ * @param dev Pointer to I2C device descriptor
+ * @param value GPIO port value
+ * @return ESP_OK on success
+ */
+esp_err_t pcf8574_port_write(i2c_dev_t *dev, uint8_t value);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/
+
+#endif /* __PCF8574_H__ */

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -27,9 +27,21 @@
 #include "speed_estimator.h"
 #include "crash_detector.h"
 
+#include "i2cdev.h"
+#include "pcf8574.h"
+
 /*******************************************************************************/
 /*                                   MACROS                                     */
 /*******************************************************************************/
+// Required for i2c_dev_t
+
+#define EXPANDER_I2C_ADDR 0x20 // From schematic
+#define I2C_PORT          I2C_NUM_0
+#define SDA_GPIO          GPIO_NUM_22 // Check schematic if different
+#define SCL_GPIO          GPIO_NUM_21
+
+i2c_dev_t expander;
+uint8_t expander_state;
 
 #define TAG                  "MAIN"
 #define TEMP_TASK_STACK_SIZE 2048
@@ -93,45 +105,84 @@ static const i2c_config_t _i2c_config = {
 /*                              PUBLIC FUNCTIONS                               */
 /*******************************************************************************/
 void app_main() {
-    ESP_LOGI(TAG, "Initializing I2C master...");
-    ESP_ERROR_CHECK(i2c_param_config(I2C_MASTER_NUM, &_i2c_config));
-    ESP_ERROR_CHECK(
-            i2c_driver_install(I2C_MASTER_NUM, _i2c_config.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0));
+    ESP_LOGI(TAG, "System boot...");
 
+    // --- Init i2cdev mutex system (MUST come before any pcf8574 or other i2cdev use) ---
+    i2cdev_init();
+
+    // --- I2C Master Init ---
+    ESP_LOGI(TAG, "Initializing I2C master...");
+    esp_err_t i2c_ret;
+
+    i2c_ret = i2c_param_config(I2C_MASTER_NUM, &_i2c_config);
+    if(i2c_ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C param config failed: %s", esp_err_to_name(i2c_ret));
+        return;
+    }
+
+    i2c_ret = i2c_driver_install(I2C_MASTER_NUM, _i2c_config.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+    if(i2c_ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C driver install failed: %s", esp_err_to_name(i2c_ret));
+        return;
+    }
+
+    // --- PCF8574 I/O Expander Init ---
+    esp_err_t err = pcf8574_init_desc(&expander, EXPANDER_I2C_ADDR, I2C_PORT, SDA_GPIO, SCL_GPIO);
+    if(err != ESP_OK) {
+        ESP_LOGE("EXPANDER", "Failed to init PCF8574 descriptor: %s", esp_err_to_name(err));
+        return;
+    }
+
+    expander_state = 0x00;
+    err            = pcf8574_port_write(&expander, expander_state); // Set all I/O expander pins LOW
+    if(err != ESP_OK) {
+        ESP_LOGE("EXPANDER", "Failed to write to PCF8574: %s", esp_err_to_name(err));
+        return;
+    }
+
+    ESP_LOGI("EXPANDER", "PCF8574 initialized and all pins set LOW");
+
+    // --- Start I2C Temperature/Humidity Sensor ---
     if(sht3x_start_periodic_measurement() != ESP_OK) {
         ESP_LOGE(TAG, "Failed to start SHT3x periodic measurement!");
         return;
     }
 
+    // --- Initialize UI + perf monitor ---
     gui_init();
     perfmon_start();
 
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(1000));
 
-    ESP_LOGI(TAG, "Creating temperature sensor task...");
+    // --- Launch core tasks ---
+    ESP_LOGI(TAG, "Launching sensor tasks...");
     xTaskCreate(temp_sens_task, "temp_sens_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
     xTaskCreate(rtc_task, "rtc_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
-    xTaskCreate(button_task, "button_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
     xTaskCreate(eeprom_task, "eeprom_task", 2 * TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
-    //xTaskCreate(joystick_task, "joystick_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
-    xTaskCreate(buzzer_task, "buzzer_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
-    //xTaskCreate(led_task, "led_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
-    //xTaskCreate(accelerometer_task, "accelerometer_task", 4096, NULL, 5, NULL);
-    // xTaskCreate(tcrt5000_task, "tcrt5000_task", 4096, NULL, 5, NULL);
-    // xTaskCreate(veml7700_task, "veml7700_task", 4096, NULL, 5, NULL);
-    // xTaskCreate(ultrasonic_task, "ultrasonic_task", 4096, NULL, 5, NULL);
-
-    xTaskCreate(speed_estimator_task, "speed_estimator", 4096, NULL, 5, NULL);
+    xTaskCreate(accelerometer_task, "accelerometer_task", 4096, NULL, 5, NULL);
     xTaskCreate(parking_sensor_task, "parking_sensor", 4096, NULL, 5, NULL);
     xTaskCreate(day_night_task, "day_night_sensor", 4096, NULL, 5, NULL);
     xTaskCreate(door_detector_task, "door_detector", 4096, NULL, 5, NULL);
 
-    vTaskDelay(2000 / portTICK_PERIOD_MS);
+    // Optional tasks (uncomment if needed)
+    // xTaskCreate(button_task, "button_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
+    // xTaskCreate(joystick_task, "joystick_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
+    // xTaskCreate(buzzer_task, "buzzer_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
+    // xTaskCreate(led_task, "led_task", TEMP_TASK_STACK_SIZE, NULL, TEMP_TASK_PRIORITY, NULL);
+    // xTaskCreate(tcrt5000_task, "tcrt5000_task", 4096, NULL, 5, NULL);
+    // xTaskCreate(veml7700_task, "veml7700_task", 4096, NULL, 5, NULL);
+    // xTaskCreate(ultrasonic_task, "ultrasonic_task", 4096, NULL, 5, NULL);
+    // xTaskCreate(speed_estimator_task, "speed_estimator", 4096, NULL, 5, NULL);
 
+    vTaskDelay(pdMS_TO_TICKS(2000));
+
+    // --- Crash detector ---
+    ESP_ERROR_CHECK(crash_detector_init());
     xTaskCreate(crash_detector_task, "crash_detector", 4096, NULL, 5, NULL);
 
-    ESP_LOGI(TAG, "All sensor tasks started");
+    ESP_LOGI(TAG, "All sensor tasks started.");
 }
+
 
 /*******************************************************************************/
 /*                             PRIVATE FUNCTIONS                               */
@@ -143,12 +194,14 @@ static void accelerometer_task(void *args) {
     // This delay ensures gui_init is done before calling LIS..._init()
     vTaskDelay(1000 / portTICK_PERIOD_MS);
     LIS2DH12TR_init();
+    vTaskDelete(NULL);
 
-    while(1) {
-        LIS2DH12TR_read_acc(&acc);
-        ESP_LOGI(TAG, "x: %f, y: %f, z: %f", acc.x_acc, acc.y_acc, acc.z_acc);
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
-    }
+
+    // while(1) {
+    //     LIS2DH12TR_read_acc(&acc);
+    //     ESP_LOGI(TAG, "x: %f, y: %f, z: %f", acc.x_acc, acc.y_acc, acc.z_acc);
+    //     vTaskDelay(1000 / portTICK_PERIOD_MS);
+    // }
 }
 
 static void temp_sens_task(void *args) {

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,16 @@
+## IDF Component Manager Manifest File
+dependencies:
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true


### PR DESCRIPTION
- enable PCF8574PWR expander module
- move crash detection signal pin to the expander pin 0
- move the digital input pin from the infrared sensor to the expander pin 1
- add i2cdev component needed for pcf8574
- modify tcrt5000 driver to use pcf8574 pin
- modify main to test out the new stuff